### PR TITLE
Add INPUT and FORWARD zone to the known ones

### DIFF
--- a/susefirewall2-to-firewalld
+++ b/susefirewall2-to-firewalld
@@ -353,7 +353,7 @@ firewalld_reset() {
 firewalld_known_chain() {
     local chain
 
-    for chain in ${!chain_mappings[@]}; do
+    for chain in ${!chain_mappings[@]} INPUT FORWARD; do
         [[ ${1} == ${chain} ]] && return 0
     done
     return 1


### PR DESCRIPTION
If we use the '-c' option, then we really want to convert the runtime
configuration into a permanent one so they changes are preserved after
the service is restarted

Fixes: #4